### PR TITLE
[Feature] remove error while getting 0 day

### DIFF
--- a/src/Manipulator.php
+++ b/src/Manipulator.php
@@ -185,10 +185,6 @@ class Manipulator implements ManipulatorInterface
      */
     public function subBusinessDays($howManyDays, $strategy = self::EXCLUDE_TODAY)
     {
-        if ($howManyDays < 1) {
-            throw new \InvalidArgumentException('The paramter $howManyDays must be greater than 0');
-        }
-        
         $today = new \DateTime();
 
         if ($today->format('Y-m-d') === $this->cursorDate->format('Y-m-d')) {
@@ -222,10 +218,6 @@ class Manipulator implements ManipulatorInterface
      */
     public function addBusinessDays($howManyDays, $strategy = self::EXCLUDE_TODAY)
     {
-        if ($howManyDays < 1) {
-            throw new \InvalidArgumentException('The paramter $howManyDays must be greater than 0');
-        }
-        
         $today = new \DateTime();
 
         if ($today->format('Y-m-d') === $this->cursorDate->format('Y-m-d')) {

--- a/tests/ManipulatorTest.php
+++ b/tests/ManipulatorTest.php
@@ -126,20 +126,24 @@ class ManipulatorTest extends \PHPUnit_Framework_TestCase
     {
         $manipulator = new Manipulator();
 
-        $manipulator->setStartDate(new \DateTime());
+        $date = new \DateTime();
+
+        $manipulator->setStartDate($date);
         $manipulator->addBusinessDays(5);
 
-        $this->assertEquals(new \DateTime('now + 5 days'), $manipulator->getDate());
+        $this->assertEquals($date->modify('+5 day'), $manipulator->getDate());
     }
 
     public function testSubBusinessDays()
     {
         $manipulator = new Manipulator();
 
-        $manipulator->setStartDate(new \DateTime());
+        $date = new \DateTime();
+
+        $manipulator->setStartDate($date);
         $manipulator->subBusinessDays(5);
 
-        $this->assertEquals(new \DateTime('now - 5 days'), $manipulator->getDate());
+        $this->assertEquals($date->modify('-5 day'), $manipulator->getDate());
     }
 
     public function testIsBusinessDay()


### PR DESCRIPTION
Hi, IMO, the checking on `$howManyDays` breaks the handling of `EXCLUDE_TODAY`.
Also, I think methods subBusinessDays and addBusinessDays are able to support zero or negative number. It won't trigger any issue even w/o this checking.